### PR TITLE
fix: publish via npm trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,14 @@ jobs:
     uses: unional/.github/.github/workflows/yarn-verify-linux.yml@main
 
   release:
-    uses: unional/.github/.github/workflows/yarn-release-semantic.yml@main
+    uses: unional/.github/.github/workflows/yarn-release-semantic-oidc.yml@main
     needs: code
-    secrets: inherit
+    # Declaring `permissions:` replaces the default, so every scope the callee needs must
+    # be listed here — unlisted ones drop to `none`, not to the default. id-token mints
+    # the OIDC token npm exchanges for short-lived publish credentials; issues and
+    # pull-requests are for @semantic-release/github commenting on what a release closes.
+    permissions:
+      id-token: write
+      contents: write
+      issues: write
+      pull-requests: write


### PR DESCRIPTION
Releases have failed since 2026-05-19 — `npm error code E401` / `401 Unauthorized - GET https://registry.npmjs.org/-/whoami`. The repo's `NPM_TOKEN` is expired, and the failing call is `@semantic-release/npm`'s own auth pre-check, which is exactly the step trusted publishing removes.

The same log also shows OIDC was never reachable:

```
[@semantic-release/npm] › ℹ  Retrieval of GitHub Actions OIDC token failed:
  Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable
```

because the release job declared no `permissions:` block.

## Change

Point `release` at `unional/.github`'s `yarn-release-semantic-oidc.yml` and grant the four scopes the callee needs. `secrets: inherit` is dropped — the workflow needs no secrets at all.

Declaring `permissions:` **replaces** the default rather than extending it, so unlisted scopes drop to `none`. All four are listed:

| scope | why |
| --- | --- |
| `id-token: write` | mints the OIDC token npm exchanges for short-lived publish credentials |
| `contents: write` | semantic-release pushes tags and creates the GitHub release |
| `issues: write`, `pull-requests: write` | `@semantic-release/github` comments on what a release closes |

The repo's `default_workflow_permissions` is `write`, so the caller can grant these. Tightening it to `read` is a later phase and must come *after* this lands, not before.

## Hazards checked

- **semantic-release/npm#1069** (`ENONPMTOKEN` under correct OIDC config) — closed 2026-01-23, resolved as an `.npmrc` fault rather than a plugin bug. The reusable workflow deliberately omits `registry-url` on `setup-node`, which is what produced it.
- **semantic-release/npm#1023** (first publish from a *maintenance* branch fails `E401` on `dist-tag add`, npm/cli#8547) — still open, but `.releaserc.json` releases from `main`/`next`/`beta` with no maintenance range, so it does not apply.
- The workflow pins `semantic-release@25` + `@semantic-release/npm@13.1.5`; both are still the current latest, so the pin is known-good.

A trusted publisher for `color-map` naming this repo and `release.yml` is registered alongside this.

Not proof until `npm view color-map version` advances past 2.0.6.