### PR TITLE
fix: release without pushing a changelog commit to main

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -7,21 +7,7 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
-    [
-      "@semantic-release/changelog",
-      {
-        "changelogFile": "CHANGELOG.md"
-      }
-    ],
     "@semantic-release/npm",
-    "@semantic-release/github",
-    [
-      "@semantic-release/git",
-      {
-        "assets": [
-          "CHANGELOG.md"
-        ]
-      }
-    ]
+    "@semantic-release/github"
   ]
 }


### PR DESCRIPTION
Follow-up to #203. **The OIDC half worked** — run [31266484487](https://github.com/unional/color-map/actions/runs/31266484487) logged:

```
[@semantic-release/npm] › ℹ  Verifying OIDC context for publishing from GitHub Actions
[@semantic-release/npm] › ℹ  OIDC token exchange with the npm registry succeeded
```

That is `yarn-release-semantic-oidc.yml` validated end to end on the auth path. `semantic-release` then resolved the next version as `2.0.7` and got as far as `prepare`.

It failed there, in a plugin unrelated to publishing:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - 5 of 5 required status checks are expected.
 ! [remote rejected] HEAD -> main (protected branch hook declined)
```

## Why this is not just stale config

`@semantic-release/git` commits `CHANGELOG.md` and pushes it **directly to `main`**. This repo's legacy branch protection requires five contexts that no run produces any more — `code / verify (ubuntu-latest, 14 | 16 | 18)` and `codecov/patch`, left over from a matrix that now runs `lts/*` and `lts/-1`.

But fixing those contexts would **not** fix this. A direct push to `main` is rejected under correct protection too: the required check has not run for that commit, and `github-actions[bot]` is not among the standard ruleset's `bypass_actors` (which cover DeployKey and the Maintain/Admin repository roles, not the Actions app). The commit-back is structurally incompatible with a protected default branch — which is exactly why the reference implementation, `cyberuni/search-packages`, uses changesets, where versioning lands through a PR instead.

## Change

Drop `@semantic-release/git` and `@semantic-release/changelog` from `.releaserc.json`.

Still works unchanged: commit analysis, release notes, **npm publish via OIDC with provenance**, the version tag (`refs/tags/*` is a different ref and unaffected by branch protection on `main`), and the GitHub release carrying the notes.

Lost: the in-repo `CHANGELOG.md` commit-back. `CHANGELOG.md` freezes at its current contents until the changesets conversion, which regenerates it from a version PR rather than a direct push. The notes themselves are not lost — they live on each GitHub release.

`@semantic-release/changelog` goes too, since its only consumer was the git plugin; left in, it would write a file nothing commits.

The `@semantic-release/*` devDependencies are left in place — `.depcheckrc.yaml` ignores them, the release workflow installs its own pinned `semantic-release@25` + `@semantic-release/npm@13.1.5`, and the changesets conversion removes that whole cluster at once rather than churning `yarn.lock` twice.

## Separately

The stale required contexts still block *every* PR in this repo — #203 and this one both need an admin merge. That is settings drift for the `apply-repo-baseline` phase, not something to fix in a release PR, and it is tracked.

Not proof until `npm view color-map version` shows 2.0.7.