### PR TITLE
fix: point package metadata at cyberuni/color-map

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,6 +2,11 @@ name: pull-request
 on:
   pull_request:
     types: [opened, synchronize]
+  # The merge queue builds a temporary branch that fires neither `pull_request` nor
+  # `push`, so without this trigger the required `code / all-checks` context never
+  # starts and the queue waits on it forever. This must be on the default branch
+  # before the merge_queue rule is added to the ruleset.
+  merge_group:
 
 jobs:
   code:

--- a/README.md
+++ b/README.md
@@ -72,12 +72,12 @@ git push
 # create PR
 ```
 
-[codecov-image]: https://codecov.io/gh/unional/color-map/branch/master/graph/badge.svg
-[codecov-url]: https://codecov.io/gh/unional/color-map
+[codecov-image]: https://codecov.io/gh/cyberuni/color-map/branch/main/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/cyberuni/color-map
 [downloads-image]: https://img.shields.io/npm/dm/color-map.svg?style=flat
 [downloads-url]: https://npmjs.org/package/color-map
-[github-nodejs]: https://github.com/unional/color-map/workflows/nodejs/badge.svg
-[github-action-url]: https://github.com/unional/color-map/actions
+[github-nodejs]: https://github.com/cyberuni/color-map/actions/workflows/pull-request.yml/badge.svg
+[github-action-url]: https://github.com/cyberuni/color-map/actions
 [npm-image]: https://img.shields.io/npm/v/color-map.svg?style=flat
 [npm-url]: https://npmjs.org/package/color-map
 [semantic-release-image]: https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg

--- a/package.json
+++ b/package.json
@@ -2,13 +2,13 @@
   "name": "color-map",
   "version": "0.0.0-development",
   "description": "Color map generator",
-  "homepage": "https://github.com/unional/color-map",
+  "homepage": "https://github.com/cyberuni/color-map",
   "bugs": {
-    "url": "https://github.com/unional/color-map/issues"
+    "url": "https://github.com/cyberuni/color-map/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/unional/color-map.git"
+    "url": "https://github.com/cyberuni/color-map.git"
   },
   "license": "MIT",
   "author": {


### PR DESCRIPTION
Follow-up to the transfer from `unional` to `cyberuni`.

## Why this is not cosmetic

`package.json` `repository` is **read when generating provenance**. GitHub redirects the old URLs, but text embedded in a published artifact does not follow redirects — leaving it stale would ship the wrong source URL inside the SLSA attestation of every future release. `homepage` and `bugs` come along for consistency.

## Changes

| File | Change |
|---|---|
| `package.json` | `repository`, `homepage`, `bugs` → `cyberuni/color-map` |
| `README.md` | codecov badges off the `unional` path **and** off `branch/master`, which has not existed for years; the `nodejs` workflow badge repointed at `pull-request.yml`, which replaced it |
| `.github/workflows/pull-request.yml` | add the `merge_group:` trigger |

## About `merge_group:`

This is the merge queue's hard precondition, and the order is not negotiable. The queue builds a temporary branch that fires neither `pull_request` nor `push`. Without this trigger, the required `code / all-checks` context never starts and the queue waits on it **forever**. The trigger must be on the default branch *before* the `merge_queue` rule is added to the ruleset — the reverse order strands every PR.

The `merge_queue` rule itself follows in a separate change once this is on `main`, together with turning `strict` off (the queue tests each candidate against the real base, so requiring up-to-date branches is redundant and strands PRs before they even enqueue).

## Note on the workflow references

`uses:` still points at `unional/.github`, deliberately and unchanged. That repo is public, cyberuni's Actions policy is `allowed_actions: all`, and the reference implementation `cyberuni/search-packages` already calls `unional/.github` cross-org from inside cyberuni. cyberuni's own release workflows check out with `secrets.CI_GITHUB_TOKEN`, so moving onto them would put a PAT back into the release path and contradict the goal of removing that secret entirely.

## Repo state this lands into

Trusted publishing was re-registered against `cyberuni/color-map` immediately after the transfer (`file: release.yml`, `permissions: publish`) — the previous registration pinned `unional/color-map` and silently stopped matching the moment the repo moved.

The stale required contexts that made this repo unmergeable (`code / verify (ubuntu-latest, 14|16|18)`, `codecov/patch`) have been replaced by the single context it actually produces, so **this PR should merge through the real gate rather than an admin bypass** — which is itself the check that the fix worked.

Merging this publishes 2.0.8, the first release from the new owner. Per the transfer procedure the move is not done until that happens, and `npm view color-map version` is the proof, not a green run.