### PR TITLE
chore: arm renovate automerge so dependency PRs enqueue

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,16 @@
 {
-  "extends": [
-    "github>unional/renovate-preset"
+  "extends": ["github>unional/renovate-preset"],
+  "platformAutomerge": true,
+  "packageRules": [
+    {
+      "description": "Auto-merge non-major updates. Majors stay manual.",
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true
+    },
+    {
+      "description": "@types/node tracks the supported Node range, so bumps are a deliberate call.",
+      "matchPackageNames": ["@types/node"],
+      "automerge": false
+    }
   ]
 }


### PR DESCRIPTION
Closes a gap I opened in #206.

## What was wrong

Retiring Mergify removed what had been merging dependency PRs, and nothing replaced it.

The merge queue and auto-merge are two different things:

- the **queue** serializes and merges what is *enqueued* — verified working here (#199 on `43c1c63`, #194 on `dc0e29d`, #206 on `b913233`, each rebuilt on the previous merge commit)
- something must **arm auto-merge** to enqueue a PR in the first place

Nothing was doing the second. The published `unional/renovate-preset` is only:

```json
{ "description": "Preserving Semver", "extends": ["config:base", ":preserveSemverRanges"] }
```

No `platformAutomerge`, no automerge `packageRules`. The two dependency PRs that landed did so because auto-merge was armed by hand, which is not a mechanism.

## Fix

Matches `cyberuni/search-packages`' `.github/renovate.json` — the reference implementation solves this **repo-locally** rather than by changing the shared preset, which every repo in the sweep extends. Same shape, same reasoning:

- non-major updates (`minor`, `patch`, `pin`, `digest`) auto-merge
- **majors stay manual** — they break builds in ways CI catches but humans should choose to absorb
- `@types/node` stays manual, since it tracks the supported Node range

With `platformAutomerge`, Renovate arms GitHub's native auto-merge, which enqueues natively and feeds the queue rather than bypassing it — the property Mergify's direct `merge` action lacked, and the reason it was retired.

Note `apply-repo-baseline`'s `assets/renovate-preset.json` *does* contain all of this, but it was never published to `unional/renovate-preset`, and the skill itself says "when they disagree, the published one is what actually runs". Publishing it would fix every repo at once; that is a separate call with a much wider blast radius, so this PR does the local thing the reference implementation already proves.