### PR TITLE
ci: run verify through cyberuni's reusable workflow

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -9,4 +9,15 @@ on:
 
 jobs:
   code:
-    uses: unional/.github/.github/workflows/pnpm-verify-linux.yml@main
+    uses: cyberuni/.github/.github/workflows/pnpm-verify.yml@main
+    with:
+      # cyberuni's default matrix is 3 OS x 2 Node. This is a small pure-TS library with
+      # no platform-specific behaviour, so ubuntu alone is the honest coverage and keeps
+      # the queue fast. It also sidesteps that workflow's unconditional Xvfb step, which
+      # has no counterpart on the macOS and Windows runners.
+      os: '["ubuntu-latest"]'
+      # No browser tests — jest only.
+      skip-playwright: true
+      # No codecov integration on this repo; its stale codecov contexts were part of what
+      # made it unmergeable.
+      skip-codecov: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,11 @@ on:
 
 jobs:
   code:
-    uses: unional/.github/.github/workflows/pnpm-verify-linux.yml@main
+    uses: cyberuni/.github/.github/workflows/pnpm-verify.yml@main
+    with:
+      os: '["ubuntu-latest"]'
+      skip-playwright: true
+      skip-codecov: true
 
   release:
     uses: cyberuni/.github/.github/workflows/pnpm-release-semantic-oidc.yml@main


### PR DESCRIPTION
The release job already calls cyberuni. The `code` job was still reaching into `unional` — a **personal namespace** — for a repo that now lives in the org. That is precisely the single point of failure the transfer was meant to remove.

## Not a like-for-like swap

cyberuni exposes `pnpm-verify.yml`, not `pnpm-verify-linux.yml`, and its default matrix is **3 OS × 2 Node = 6 jobs** where this repo ran 2. That is a real cost increase for a small pure-TypeScript library with no platform-specific behaviour, so the `os` input pins it back to ubuntu and two jobs.

Pinning ubuntu also sidesteps a latent issue in that workflow: its `Start X Virtual Frame Buffer` step runs **unconditionally**, invoking `Xvfb`, which has no counterpart on the macOS or Windows runners its own default matrix includes. Worth fixing there separately; not this PR's business.

| input | value | why |
|---|---|---|
| `os` | `["ubuntu-latest"]` | honest coverage for a pure-TS library; keeps the queue fast |
| `skip-playwright` | `true` | no browser tests — jest only |
| `skip-codecov` | `true` | no codecov integration here, and **stale codecov contexts were part of what made this repo unmergeable** |

## The required context is unchanged

cyberuni's workflow keeps the same `all-checks` job, so the caller job id `code` still produces **`code / all-checks`** — the context the ruleset requires. This PR merging through the queue without an admin bypass is itself the proof.

With this, color-map calls cyberuni for both jobs and depends on `unional/*` for nothing.