### PR TITLE
ci: enable the codecov upload, and drop the stale semantic-release badge

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -18,9 +18,10 @@ jobs:
       os: '["ubuntu-latest"]'
       # No browser tests — vitest runs in node.
       skip-playwright: true
-      # No codecov integration on this repo; its stale codecov contexts were part of what
-      # made it unmergeable.
-      skip-codecov: true
+      # `skip-codecov` stays at its `false` default: the upload feeds the README badge.
+      # It gates nothing. `codecov/project` and `codecov/patch` must never be required
+      # status contexts — requiring them is what made this repo unmergeable, and the
+      # merge gate is `code / all-checks` alone.
 
   # The release PR is the last point where the next publish is reviewable; after it
   # merges, release.yml publishes unattended. Only runs there, so ordinary PRs are

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,6 @@ jobs:
     with:
       os: '["ubuntu-latest"]'
       skip-playwright: true
-      skip-codecov: true
 
   # changesets, not semantic-release: a push to main only opens or updates the
   # "Version Packages" PR, so nothing reaches npm until that PR is merged. That second

--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@
 [![Github NodeJS][github-nodejs]][github-action-url]
 [![Codecov][codecov-image]][codecov-url]
 
-[![Semantic Release][semantic-release-image]][semantic-release-url]
-
 [![Visual Studio Code][vscode-image]][vscode-url]
 [![Wallaby.js][wallaby-image]][wallaby-url]
 
@@ -80,8 +78,6 @@ git push
 [github-action-url]: https://github.com/cyberuni/color-map/actions
 [npm-image]: https://img.shields.io/npm/v/color-map.svg?style=flat
 [npm-url]: https://npmjs.org/package/color-map
-[semantic-release-image]: https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg
-[semantic-release-url]: https://github.com/semantic-release/semantic-release
 [vscode-image]: https://img.shields.io/badge/vscode-ready-green.svg
 [vscode-url]: https://code.visualstudio.com/
 [wallaby-image]: https://img.shields.io/badge/wallaby.js-configured-green.svg


### PR DESCRIPTION
Follow-up to #212 / #213, and the last piece of the coverage decision.

## What

- `skip-codecov: true` removed from both `pull-request.yml` and `release.yml`, so the input falls back to its `false` default and coverage is uploaded again.
- The `Semantic Release` badge and its link definitions removed from the root README — left over from #212, which moved this repo to changesets.

## Why

Owner direction, 2026-08-08: **coverage is never a merge gate in CI**, but the codecov upload stays on so the README badge means something. Recorded as §15 of the `reference: secretless release approach` board card.

The README has carried a Codecov badge this whole time while `skip-codecov: true` guaranteed nothing was ever uploaded to back it. Either the badge goes or the upload comes back — and the badge is the part that was wanted.

**`codecov/project` and `codecov/patch` must never become required status contexts.** Requiring them is exactly what made this repo unmergeable (13 of 13 open PRs blocked at one point), and the ban holds even when the integration is healthy. The merge gate stays `code / all-checks` alone. A broken upload must degrade to a stale badge, never a blocked PR.

## Coverage enforcement is unaffected

`packages/color-map/vitest.config.ts` already pins 100% thresholds on branches/functions/lines/statements. That runs inside `pnpm verify`, so a coverage drop fails the `verify` job and therefore `code / all-checks` — the same as any failing test. Nothing in this PR changes that, and it is not what the "no CI gate" rule is about: the rule bans depending on an external service's status checks, not the test suite asserting its own coverage.

## Notes

- Repo-internal only, so no changeset — nothing publishes.
- Titled `ci:` deliberately.
- The published package README is `packages/color-map/README.md` and is untouched; this only edits the root README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)